### PR TITLE
fix: force drain to use delete

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "docker_container" "k3s_server" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "docker exec ${self.name} kubectl drain ${self.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets"
+    command = "docker exec ${self.name} kubectl drain ${self.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets --grace-period=60"
   }
 }
 
@@ -201,7 +201,7 @@ resource "null_resource" "destroy_k3s_agent" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "docker exec ${self.triggers.server_container_name} kubectl drain ${self.triggers.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets"
+    command = "docker exec ${self.triggers.server_container_name} kubectl drain ${self.triggers.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets --grace-period=60"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "docker_container" "k3s_server" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "docker exec ${self.name} kubectl drain --delete-emptydir-data --ignore-daemonsets ${self.hostname}"
+    command = "docker exec ${self.name} kubectl drain ${self.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets"
   }
 }
 
@@ -201,7 +201,7 @@ resource "null_resource" "destroy_k3s_agent" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "docker exec ${self.triggers.server_container_name} kubectl drain --delete-emptydir-data --ignore-daemonsets ${self.triggers.hostname}"
+    command = "docker exec ${self.triggers.server_container_name} kubectl drain ${self.triggers.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   network_name     = var.network_name == null ? docker_network.k3s.0.name : var.network_name
   cluster_endpoint = coalesce(var.cluster_endpoint, docker_container.k3s_server.ip_address)
-  server_config    = var.cluster_endpoint == null ? var.server_config : concat(["--tls-san", var.cluster_endpoint],var.server_config)
+  server_config    = var.cluster_endpoint == null ? var.server_config : concat(["--tls-san", var.cluster_endpoint], var.server_config)
 }
 
 # Mimics https://github.com/rancher/k3s/blob/master/docker-compose.yml

--- a/main.tf
+++ b/main.tf
@@ -128,10 +128,17 @@ resource "docker_container" "k3s_server" {
       protocol = ports.value.protocol
     }
   }
+}
+
+resource "null_resource" "destroy_k3s_server" {
+  triggers = {
+    server_container_name = docker_container.k3s_server.name
+    hostname              = docker_container.k3s_server.hostname
+  }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "docker exec ${self.name} kubectl drain ${self.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets --grace-period=60"
+    command = "docker exec ${self.triggers.server_container_name} kubectl drain ${self.triggers.hostname} --delete-emptydir-data --disable-eviction --ignore-daemonsets --grace-period=60"
   }
 }
 


### PR DESCRIPTION
Sometime container deletion fails because the destroy provider that
drains the node before deletion does not end. We should force drain to
use delete, even if eviction is supported. This will bypass checking
PodDisruptionBudgets.